### PR TITLE
Added a scaling option for wall and floor textures

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -47,6 +47,7 @@
   "DD.FloorOpacity": "Floor Opacity",
   "DD.FloorTexture": "Floor Texture",
   "DD.FloorTextureRotation": "Floor Texture Rotation",
+  "DD.FloorTextureScaling": "Floor Texture Scaling",
   "DD.FloorTextureTint": "Floor Texture Tint",
   "DD.Generate": "Generate",
   "DD.GenerateDoors": "Generate Doors",
@@ -66,6 +67,7 @@
   "DD.InvisibleWallLineThickness": "Invisible Wall Line Thickness",
   "DD.InvisibleWallTexture": "Invisible Wall Texture",
   "DD.InvisibleWallTextureRotation": "Invisible Wall Texture Rotation",
+  "DD.InvisibleWallTextureScaling": "Invisible Wall Texture Scaling",
   "DD.InvisibleWallTextureTint": "Invisible Wall Texture Tint",
   "DD.InvisibleWallThickness": "Invisible Wall Thickness",
   "DD.OK": "OK",
@@ -111,6 +113,7 @@
   "DD.WallOpacity": "Wall Opacity",
   "DD.WallTexture": "Wall Texture",
   "DD.WallTextureRotation": "Wall Texture Rotation",
+  "DD.WallTextureScaling": "Wall Texture Scaling",
   "DD.WallTextureTint": "Wall Texture Tint",
   "DD.WallThickness": "Wall Thickness",
   "DD.Width": "Width"

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -46,6 +46,7 @@
   "DD.FloorOpacity": "床の不透明度",
   "DD.FloorTexture": "床のテクスチャー",
   "DD.FloorTextureRotation": "床のテクスチャーの回転度",
+  "DD.FloorTextureScaling": "TODO",
   "DD.FloorTextureTint": "床のテクスチャーの色合い",
   "DD.Generate": "生成",
   "DD.GenerateDoors": "扉配置",
@@ -97,6 +98,7 @@
   "DD.WallOpacity": "ウォールの不透明度",
   "DD.WallTexture": "ウォールのテクスチャー",
   "DD.WallTextureRotation": "ウォールのテクスチャー回転度",
+  "DD.WallTextureScaling": "TODO",
   "DD.WallTextureTint": "ウォール・テクスチャーの色合い",
   "DD.WallThickness": "ウォールの厚さ",
   "DD.Width": "幅"

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -121,9 +121,12 @@ const renderPass = async (container, state) => {
     const texture = await getTexture(state.config.wallTexture);
     if (texture?.valid) {
       let matrix = null;
+      matrix = PIXI.Matrix.IDENTITY.clone();
       if (state.config.wallTextureRotation) {
-        matrix = PIXI.Matrix.IDENTITY.clone();
         matrix.rotate(state.config.wallTextureRotation * PIXI.DEG_TO_RAD);
+      }
+      if (state.config.WallTextureScaling) {
+        matrix.scale(state.config.WallTextureScaling, state.config.WallTextureScaling);
       }
       maybeStartTextureVideo(texture);
       wallGfx.beginTextureFill({
@@ -338,9 +341,12 @@ const drawPolygonRoom = async (
     const texture = await getTexture(config.floorTexture);
     if (texture?.valid) {
       let matrix = null;
+      matrix = PIXI.Matrix.IDENTITY.clone();
       if (config.floorTextureRotation) {
-        matrix = PIXI.Matrix.IDENTITY.clone();
         matrix.rotate(config.floorTextureRotation * PIXI.DEG_TO_RAD);
+      }
+      if (config.floorTextureScaling) {
+        matrix.scale(config.floorTextureScaling, config.floorTextureScaling);
       }
       maybeStartTextureVideo(texture);
       floorGfx.beginTextureFill({

--- a/src/themes.js
+++ b/src/themes.js
@@ -14,6 +14,7 @@ export const defaultConfig = () => {
     floorOpacity: 1.0,
     floorTexture: "",
     floorTextureRotation: 0,
+    floorTextureScaling: 1,
     floorTextureTint: "",
     interiorShadowColor: "#000000",
     interiorShadowThickness: 8,
@@ -39,6 +40,7 @@ export const defaultConfig = () => {
     threeDWallSidesTextureTint: "",
     wallColor: "#000000",
     wallTexture: "",
+    WallTextureScaling: 1,
     wallTextureTint: "",
     wallThickness: 8,
   };

--- a/templates/config-sheet.html
+++ b/templates/config-sheet.html
@@ -198,6 +198,20 @@
       </div>
     </div>
     <div class="form-group">
+      <label>{{localize "DD.FloorTextureScaling"}}</label>
+      <div class="form-fields">
+        <input
+          type="number"
+          name="floorTextureScaling"
+          value="{{config.floorTextureScaling}}"
+          data-dtype="Number"
+          min="0"
+          max="100"
+          step="0.05"
+        />
+      </div>
+    </div>
+    <div class="form-group">
       <label>{{localize "DD.FloorTextureTint"}}</label>
       <div class="form-fields">
         <input
@@ -329,6 +343,20 @@
           name="invisibleWallThickness"
           value="{{config.invisibleWallThickness}}"
           data-dtype="Number"
+        />
+      </div>
+    </div>
+    <div class="form-group">
+      <label>{{localize "DD.InvisibleWallTextureScaling"}}</label>
+      <div class="form-fields">
+        <input
+          type="number"
+          name="InvisibleWallTextureScaling"
+          value="{{config.InvisibleWallTextureScaling}}"
+          data-dtype="Number"
+          min="0"
+          max="100"
+          step="0.05"
         />
       </div>
     </div>
@@ -479,6 +507,20 @@
           value="{{config.wallTexture}}"
           data-dtype="String"
           placeholder="File Path"
+        />
+      </div>
+    </div>
+    <div class="form-group">
+      <label>{{localize "DD.WallTextureScaling"}}</label>
+      <div class="form-fields">
+        <input
+          type="number"
+          name="WallTextureScaling"
+          value="{{config.WallTextureScaling}}"
+          data-dtype="Number"
+          min="0"
+          max="100"
+          step="0.05"
         />
       </div>
     </div>

--- a/templates/theme-sheet.html
+++ b/templates/theme-sheet.html
@@ -189,6 +189,20 @@
       </div>
     </div>
     <div class="form-group">
+      <label>{{localize "DD.FloorTextureScaling"}}</label>
+      <div class="form-fields">
+        <input
+          type="number"
+          name="floorTextureScaling"
+          value="{{config.floorTextureScaling}}"
+          data-dtype="Number"
+          min="0"
+          max="100"
+          step="0.05"
+        />
+      </div>
+    </div>
+    <div class="form-group">
       <label>{{localize "DD.FloorTextureTint"}}</label>
       <div class="form-fields">
         <input
@@ -463,6 +477,20 @@
           value="{{config.wallTexture}}"
           data-dtype="String"
           placeholder="File Path"
+        />
+      </div>
+    </div>
+    <div class="form-group">
+      <label>{{localize "DD.WallTextureScaling"}}</label>
+      <div class="form-fields">
+        <input
+          type="number"
+          name="WallTextureScaling"
+          value="{{config.WallTextureScaling}}"
+          data-dtype="Number"
+          min="0"
+          max="100"
+          step="0.05"
         />
       </div>
     </div>


### PR DESCRIPTION
This adds a feature for scaling the texture of walls and floors.
Its implemented analogously to the rotation option for those.
I made it because i had some floor textures where the floor tiles where much to large. And it seemed odd to allow rotation and not scaling.