### PR TITLE
Save as tile

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3,6 +3,7 @@
   "DD.Algorithm": "Algorithm",
   "DD.ApplyTheme": "Apply a Theme",
   "DD.ButtonTitleClearAll": "Clear All",
+  "DD.ButtonTitleClearDrawing": "Clear Drawing (keep walls)",
   "DD.ButtonTitleConfig": "Configure",
   "DD.ButtonTitleDoor": "Door",
   "DD.ButtonTitleInvisibleWall": "Invisible Wall",

--- a/lang/en.json
+++ b/lang/en.json
@@ -16,6 +16,7 @@
   "DD.ButtonTitleRectangle": "Rectangle",
   "DD.ButtonTitleRedo": "Redo",
   "DD.ButtonTitleSaveToSceneBackground": "Save to Scene Background",
+  "DD.ButtonTitleSaveToTile": "Save to Tile",
   "DD.ButtonTitleSecretDoor": "Secret Door",
   "DD.ButtonTitleSelect": "Select",
   "DD.ButtonTitleStairs": "Stairs",

--- a/src/dungeon.js
+++ b/src/dungeon.js
@@ -218,14 +218,6 @@ export class Dungeon extends foundry.canvas.placeables.PlaceableObject {
 
     const tempContainer = new PIXI.Container();
 
-    // Anchor the PIXI extract bounds to our tight bbox
-    const sizeForcer = new PIXI.Sprite();
-    sizeForcer.width = tileWidth;
-    sizeForcer.height = tileHeight;
-    sizeForcer.position.x = minX;
-    sizeForcer.position.y = minY;
-    tempContainer.addChild(sizeForcer);
-
     // Save original parent so we can restore it after extraction.
     // PIXI's addChild reparents the object, removing it from DungeonLayer.
     const originalParent = this.parent;
@@ -236,7 +228,17 @@ export class Dungeon extends foundry.canvas.placeables.PlaceableObject {
     // previous save when the tile dimensions or position have changed.
     const folder = "";
     const filename = `${canvas.scene.name}-dungeon-tile-${Date.now()}.png`;
-    const base64 = await canvas.app.renderer.extract.base64(tempContainer);
+    // Clip the extraction to exactly the computed bounds. This ensures the
+    // extracted PNG is always tileWidth×tileHeight regardless of any sprites
+    // (e.g. corner textures) that extend beyond the wall geometry — no
+    // content scaling occurs when Foundry sizes the tile to these dimensions.
+    const frame = new PIXI.Rectangle(minX, minY, tileWidth, tileHeight);
+    const base64 = await canvas.app.renderer.extract.base64(
+      tempContainer,
+      "image/png",
+      1.0,
+      frame
+    );
     const res = await fetch(base64);
     const blob = await res.blob();
     const file = new File([blob], filename, { type: "image/png" });

--- a/src/dungeon.js
+++ b/src/dungeon.js
@@ -2,6 +2,7 @@ import { DungeonState } from "./dungeonstate.js";
 import { render } from "./renderer.js";
 import * as geo from "./geo-utils.js";
 import { getTheme, getThemePainterThemeKey } from "./themes.js";
+import * as constants from "./constants.js";
 
 /**
  * @extends {PlaceableObject}
@@ -33,6 +34,35 @@ export class Dungeon extends foundry.canvas.placeables.PlaceableObject {
 
   async deleteAll() {
     // keep our most recent config around
+    const lastState = this.state();
+    const resetState = DungeonState.startState();
+    resetState.config = lastState.config;
+    this.history = [resetState];
+    this.historyIndex = 0;
+    await this.history[this.historyIndex].saveToJournalEntry(this.journalEntry);
+    this.refresh();
+  }
+
+  /* -------------------------------------------- */
+
+  async clearDrawing() {
+    // Remove the dungeon-draw tracking flag from all DD-owned walls so they
+    // are no longer managed by this module (and won't be deleted by Clear All).
+    const ddWalls = canvas.scene
+      .getEmbeddedCollection("Wall")
+      .filter((w) =>
+        w.getFlag(constants.MODULE_NAME, constants.FLAG_DUNGEON_VERSION)
+      );
+    if (ddWalls.length) {
+      const flagPath = `flags.${constants.MODULE_NAME}.-=${constants.FLAG_DUNGEON_VERSION}`;
+      await canvas.scene.updateEmbeddedDocuments(
+        "Wall",
+        ddWalls.map((w) => ({ _id: w.id, [flagPath]: null }))
+      );
+    }
+
+    // Reset the dungeon drawing state without touching walls (makeWalls will
+    // find no DD-flagged walls left, so nothing gets deleted).
     const lastState = this.state();
     const resetState = DungeonState.startState();
     resetState.config = lastState.config;

--- a/src/dungeon.js
+++ b/src/dungeon.js
@@ -119,6 +119,128 @@ export class Dungeon extends foundry.canvas.placeables.PlaceableObject {
   }
 
   /* -------------------------------------------- */
+
+  async saveToTile() {
+    const state = this.state();
+    if (!state.geometry) {
+      return;
+    }
+
+    // Compute tight world-space bounding box from all dungeon content.
+    // All coordinates are in canvas world space (scene coords + padding offset).
+    let minX = Infinity,
+      minY = Infinity,
+      maxX = -Infinity,
+      maxY = -Infinity;
+    const expandPoint = (x, y) => {
+      if (x < minX) minX = x;
+      if (y < minY) minY = y;
+      if (x > maxX) maxX = x;
+      if (y > maxY) maxY = y;
+    };
+
+    // Main dungeon geometry
+    for (const coord of state.geometry.getCoordinates()) {
+      expandPoint(coord.x, coord.y);
+    }
+
+    // Doors, secret doors, interior walls, invisible walls, windows: [x0, y0, x1, y1]
+    for (const seg of [
+      ...state.doors,
+      ...(state.secretDoors || []),
+      ...state.interiorWalls,
+      ...(state.invisibleWalls || []),
+      ...(state.windows || []),
+    ]) {
+      expandPoint(seg[0], seg[1]);
+      expandPoint(seg[2], seg[3]);
+    }
+
+    // Stairs: { x1, y1, x2, y2, x3, y3, x4, y4 }
+    for (const stair of state.stairs || []) {
+      expandPoint(stair.x1, stair.y1);
+      expandPoint(stair.x2, stair.y2);
+      expandPoint(stair.x3, stair.y3);
+      expandPoint(stair.x4, stair.y4);
+    }
+
+    // Wall shapes (interior + invisible): [[x, y], ...]
+    for (const shape of [
+      ...(state.interiorWallShapes || []),
+      ...(state.invisibleWallShapes || []),
+    ]) {
+      for (const [x, y] of shape) {
+        expandPoint(x, y);
+      }
+    }
+
+    // Expand by wall thickness + exterior shadow to avoid clipping rendered edges
+    const margin =
+      (state.config.wallThickness || 8) +
+      (state.config.exteriorShadowThickness || 0);
+    minX -= margin;
+    minY -= margin;
+    maxX += margin;
+    maxY += margin;
+
+    const tileWidth = maxX - minX;
+    const tileHeight = maxY - minY;
+
+    const tempContainer = new PIXI.Container();
+
+    // Anchor the PIXI extract bounds to our tight bbox
+    const sizeForcer = new PIXI.Sprite();
+    sizeForcer.width = tileWidth;
+    sizeForcer.height = tileHeight;
+    sizeForcer.position.x = minX;
+    sizeForcer.position.y = minY;
+    tempContainer.addChild(sizeForcer);
+
+    // Save original parent so we can restore it after extraction.
+    // PIXI's addChild reparents the object, removing it from DungeonLayer.
+    const originalParent = this.parent;
+    const originalIndex = originalParent?.getChildIndex(this) ?? -1;
+    tempContainer.addChild(this);
+
+    // Use a timestamp suffix to avoid PIXI serving a cached texture from a
+    // previous save when the tile dimensions or position have changed.
+    const folder = "";
+    const filename = `${canvas.scene.name}-dungeon-tile-${Date.now()}.png`;
+    const base64 = await canvas.app.renderer.extract.base64(tempContainer);
+    const res = await fetch(base64);
+    const blob = await res.blob();
+    const file = new File([blob], filename, { type: "image/png" });
+    await foundry.applications.apps.FilePicker.implementation.upload(
+      "data",
+      folder,
+      file,
+      {}
+    );
+    const path = folder ? folder + "/" + filename : filename;
+
+    // Restore dungeon to its original place in DungeonLayer
+    if (originalParent) {
+      originalParent.addChildAt(this, originalIndex);
+    } else {
+      tempContainer.removeChild(this);
+    }
+
+    // Tile positions use canvas world coordinates (same space as geometry coords),
+    // so place the tile directly at the computed bounds — no offset adjustment needed.
+    await canvas.scene.createEmbeddedDocuments("Tile", [
+      {
+        texture: { src: path },
+        x: minX,
+        y: minY,
+        width: tileWidth,
+        height: tileHeight,
+        z: 0,
+        overhead: false,
+      },
+    ]);
+  }
+
+  /* -------------------------------------------- */
   /* Rendering                                    */
   /* -------------------------------------------- */
 

--- a/src/dungeondraw.js
+++ b/src/dungeondraw.js
@@ -99,6 +99,16 @@ export class DungeonDraw {
           },
           button: true,
         },
+        savetotile: {
+          name: "savetotile",
+          title: "DD.ButtonTitleSaveToTile",
+          icon: "fas fa-image",
+          visible: game.user.isGM,
+          onClick: async () => {
+            await canvas.dungeon.dungeon.saveToTile();
+          },
+          button: true,
+        },
         clear: {
           name: "clear",
           title: "DD.ButtonTitleClearAll",

--- a/src/dungeondraw.js
+++ b/src/dungeondraw.js
@@ -109,6 +109,14 @@ export class DungeonDraw {
           },
           button: true,
         },
+        cleardrawing: {
+          name: "cleardrawing",
+          title: "DD.ButtonTitleClearDrawing",
+          icon: "fas fa-eraser",
+          visible: game.user.isGM,
+          onClick: () => canvas.dungeon.dungeon?.clearDrawing(),
+          button: true,
+        },
         clear: {
           name: "clear",
           title: "DD.ButtonTitleClearAll",


### PR DESCRIPTION
This implements the ability to save the drawing as a tile rather than save it to the background. This is useful for use cases where one might want to reuse rooms across different dungeons.

It also implements the ability to clear the drawing without clearing the walls.